### PR TITLE
[BUGFIX] Fix compressImages to allow for paths with space characters

### DIFF
--- a/Classes/Command/CompressImagesCommandController.php
+++ b/Classes/Command/CompressImagesCommandController.php
@@ -77,7 +77,7 @@ class CompressImagesCommandController extends CommandController
         foreach ($files as $file) {
             if ($file instanceof \Schmitzal\Tinyimg\Domain\Model\File) {
                 $file = $this->resourceFactory->getFileObject($file->getUid());
-                if (filesize(GeneralUtility::getFileAbsFileName($file->getPublicUrl())) > 0) {
+                if (filesize(urldecode(GeneralUtility::getFileAbsFileName($file->getPublicUrl()))) > 0) {
                     $this->compressImageService->initializeCompression($file);
                     $fileDeletionAspect->cleanupProcessedFilesPostFileReplace($file, '');
                 }


### PR DESCRIPTION
If a file is located in `/tas/images/App Notes/` then the filesize() function will fail because the string from getPublicUrl contains `%20` instead of a space character. This change urldecodes the file path to correct this.