### PR TITLE
[BUGFIX] Add return type to be compatible with TYPO3 10.4.9

### DIFF
--- a/Classes/Service/LocalImageProcessor.php
+++ b/Classes/Service/LocalImageProcessor.php
@@ -15,7 +15,7 @@ class LocalImageProcessor extends \TYPO3\CMS\Core\Resource\Processing\LocalImage
      * @param TaskInterface $task
      * @throws \InvalidArgumentException
      */
-    public function processTask(TaskInterface $task)
+    public function processTask(TaskInterface $task): void
     {
         parent::processTask($task);
         if ($task->isExecuted() && $task->getTargetFile()->usesOriginalFile() === false) {


### PR DESCRIPTION
TYPO3 recently started enforcing PHPStan rules to all classes. This change was introduced with TYPO3 10.4.9. Certain functions that may have been overridden are now changed through this and the overridden functions have to be modified to be compatible.